### PR TITLE
Add sprite sheet frame extraction utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,17 @@ Jeu sidescroller
 
 Un système de score affiche la distance maximale parcourue par le joueur. Le
 score est réinitialisé en appuyant sur **R** après un Game Over.
+
+## Extraction des sprites
+
+Le script `extract_frames.py` permet de découper les sprite sheets du jeu en
+images individuelles de 256 x 341 pixels (6 colonnes × 3 lignes).
+
+Exemple d'utilisation :
+
+```bash
+python extract_frames.py Imagesidescroller/Chatanimation.png output/chat --prefix chat
+python extract_frames.py Imagesidescroller/Chienanimation.png output/chien --prefix chien
+```
+
+Les images générées sont stockées dans le dossier indiqué.

--- a/extract_frames.py
+++ b/extract_frames.py
@@ -1,0 +1,75 @@
+"""Extract frames from sprite sheets.
+
+This helper script slices sprite sheets into individual frames of 256x341 pixels
+arranged in 6 columns by 3 rows. The extracted frames are saved to a destination
+folder.
+
+Usage examples::
+
+    python extract_frames.py Imagesidescroller/Chatanimation.png output/chat --prefix chat
+    python extract_frames.py Imagesidescroller/Chienanimation.png output/dog --prefix chien
+
+Dependencies: Pillow
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Tuple
+
+from PIL import Image
+
+
+def extract_frames(
+    image_path: Path,
+    output_dir: Path,
+    frame_size: Tuple[int, int] = (256, 341),
+    cols: int = 6,
+    rows: int = 3,
+    prefix: str = "frame",
+) -> None:
+    """Split *image_path* into frames and store them in *output_dir*.
+
+    Parameters
+    ----------
+    image_path:
+        Path to the sprite sheet image.
+    output_dir:
+        Directory where extracted frames will be written.
+    frame_size:
+        Width and height of each frame in pixels.
+    cols, rows:
+        Number of columns and rows in the sprite sheet.
+    prefix:
+        Prefix for generated frame filenames.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with Image.open(image_path) as image:
+        frame_width, frame_height = frame_size
+        frame_num = 0
+        for row in range(rows):
+            for col in range(cols):
+                left = col * frame_width
+                upper = row * frame_height
+                right = left + frame_width
+                lower = upper + frame_height
+                frame = image.crop((left, upper, right, lower))
+                frame.save(output_dir / f"{prefix}_{frame_num:02d}.png")
+                frame_num += 1
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Slice sprite sheets")
+    parser.add_argument("image", type=Path, help="path to sprite sheet")
+    parser.add_argument("output", type=Path, help="directory to save frames")
+    parser.add_argument(
+        "--prefix", default="frame", help="prefix for output image names"
+    )
+    args = parser.parse_args()
+
+    extract_frames(args.image, args.output, prefix=args.prefix)
+
+
+if __name__ == "__main__":  # pragma: no cover - simple CLI
+    main()


### PR DESCRIPTION
## Summary
- add `extract_frames.py` script to slice sprite sheets into 256x341 frames
- update README with instructions for using the new script

## Testing
- `python -m py_compile extract_frames.py sidescroller_chat.py`

------
https://chatgpt.com/codex/tasks/task_e_684f0bfab4f4832dbd9a97a5f577e77e