### PR TITLE
Fix default sprite sheet dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Un système de score affiche la distance maximale parcourue par le joueur. Le sc
 
 ## Extraction des sprites
 
-Le script `extract_frames.py` permet de découper les sprite sheets du jeu en images individuelles de 256 × 341 pixels (6 colonnes × 3 lignes).
+Le script `extract_frames.py` permet de découper les sprite sheets du jeu en images individuelles de 256 × 256 pixels (6 colonnes × 4 lignes).
 
 Exemple d'utilisation :
 

--- a/extract_frames.py
+++ b/extract_frames.py
@@ -1,7 +1,7 @@
 """Extract frames from sprite sheets.
 
-This helper script slices sprite sheets into individual frames of 256x341 pixels
-arranged in 6 columns by 3 rows. The extracted frames are saved to a destination
+This helper script slices sprite sheets into individual frames of 256×256 pixels
+arranged in 6 columns by 4 rows. The extracted frames are saved to a destination
 folder.
 
 Usage examples::
@@ -24,9 +24,9 @@ from PIL import Image
 def extract_frames(
     image_path: Path,
     output_dir: Path,
-    frame_size: Tuple[int, int] = (256, 341),
+    frame_size: Tuple[int, int] = (256, 256),
     cols: int = 6,
-    rows: int = 3,
+    rows: int = 4,
     prefix: str = "frame",
 ) -> None:
     """Split *image_path* into frames and store them in *output_dir*.


### PR DESCRIPTION
## Summary
- correct sprite sheet slicing defaults (256x256, 6x4)
- update README to mention the new frame size

## Testing
- `python -m py_compile extract_frames.py sidescroller_chat.py`

------
https://chatgpt.com/codex/tasks/task_e_684f116dc95c832dbda70043f9682d37