### PR TITLE
Fix unused import

### DIFF
--- a/extract_frames.py
+++ b/extract_frames.py
@@ -14,7 +14,6 @@ Dependencies: Pillow
 from __future__ import annotations
 
 import argparse
-import os
 from pathlib import Path
 from typing import Tuple
 


### PR DESCRIPTION
## Summary
- remove unused `os` import from `extract_frames.py`

## Testing
- `python -m py_compile extract_frames.py`


------
https://chatgpt.com/codex/tasks/task_e_684f14943d98832da671754a5bcbaff1